### PR TITLE
Add packages recursively

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from setuptools.command.test import test as TestCommand
+from setuptools import find_packages
 import pytopol
 
 try:
@@ -46,9 +47,7 @@ setup(
     author='Reza Salari',
     author_email='rezasalari@rutgers.edu',
     url='https://github.com/resal81/pytopol',
-    packages=[
-        'pytopol',
-    ],
+    packages=find_packages(),
     package_dir={'pytopol': 'pytopol'},
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
The parsers and general sub-packages were missing from pipy,
setuptools does not add sub-packages resursively by default.

This would allow people to use pip install pytopol

Fixes issue #24 

@resal81 would it be possible to release a new version on pypi with this fix?
it would make it a lot easier to use your package in our lab.